### PR TITLE
Work around fix for LLDB crash when inspecting ni::type_hierarchy objects

### DIFF
--- a/include/ni/type_hierarchy.h
+++ b/include/ni/type_hierarchy.h
@@ -128,7 +128,7 @@ namespace type_hierarchy_detail {
 
     // the types 'type<>' manage the ids which are used by identify each type at runtime
 
-    template <typename Config, typename... >
+    template <typename Config, typename... T>
     struct id_holder;
 
     template <typename Config>


### PR DESCRIPTION
# What:
* Crash in LLDB when inspecting ni::type_hierarchy objects
* Issue: https://github.com/NativeInstruments/matchine/issues/1

# How:
A bug was filed with LLDB: https://bugs.llvm.org/show_bug.cgi?id=48342

Raphael Isemann commented `LLDB is unable to handle the unnamed template parameter pack in ni:type_hierarchy_detail::id_holder.`

Changing line 131 in `type_hierarchy.h`,  `template <typename Config, typename...>` to ` template <typename Config, typename... T>` prevents the crash when inspecting objects using the LLDB debugger. 

This is a work around fix until LLDB supports unnamed template parameter pack. 

